### PR TITLE
remove python 3.11 limit

### DIFF
--- a/.github/workflows/python-mypy.yml
+++ b/.github/workflows/python-mypy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-mypy.yml
+++ b/.github/workflows/python-mypy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-entry-points.yml
+++ b/.github/workflows/run-entry-points.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-- attune now works up to python 3.11 (resolved upstream)
+- roll python tests to 3.12-14
 
 ## [2023.3.0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dist-name = "yaqd-attune"
 author = "yaq developers"
 home-page = "https://yaq.fyi"
 description-file = "README.md"
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.7"
 requires = ["attune", "yaqd-core>=2022.7.0", "yaqc"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
After more than two years, there is no reason to keep the pin--issues from dependencies have been resolved.

* resolves #41 