### PR TITLE
handle numpy scalars from attune Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 - attune now works up to python 3.11 (resolved upstream)
+- integration to work with attune 0.5.2
 
 ## [2023.3.0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author = "yaq developers"
 home-page = "https://yaq.fyi"
 description-file = "README.md"
 requires-python = ">=3.7,<3.12"
-requires = ["attune", "yaqd-core>=2022.7.0", "yaqc"]
+requires = ["attune>0.5.1", "yaqd-core>=2022.7.0", "yaqc"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author = "yaq developers"
 home-page = "https://yaq.fyi"
 description-file = "README.md"
 requires-python = ">=3.7,<3.12"
-requires = ["attune>0.5.1", "yaqd-core>=2022.7.0", "yaqc"]
+requires = ["attune", "yaqd-core>=2022.7.0", "yaqc"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",

--- a/yaqd_attune/_attune.py
+++ b/yaqd_attune/_attune.py
@@ -49,10 +49,7 @@ class Attune(HasDependents, HasLimits, IsHomeable, HasPosition, IsDaemon):
         for name, set_pos in self._instrument(position, self._state["arrangement"]).items():
             if name in exceptions:
                 continue
-            try:
-                set_pos = set_pos.item()
-            except AttributeError:
-                pass
+            set_pos = set_pos.item()  # needs attune > 0.5.1
             if isinstance(set_pos, str):
                 self._setables[name].set_identifier(set_pos)
             elif set_pos is None:

--- a/yaqd_attune/_attune.py
+++ b/yaqd_attune/_attune.py
@@ -2,6 +2,7 @@ __all__ = ["Attune"]
 
 import asyncio
 from typing import Dict, Any, List, Union, Optional
+import numpy as np
 
 import attune  # type: ignore
 import yaqc  # type: ignore
@@ -48,6 +49,10 @@ class Attune(HasDependents, HasLimits, IsHomeable, HasPosition, IsDaemon):
         for name, set_pos in self._instrument(position, self._state["arrangement"]).items():
             if name in exceptions:
                 continue
+            try:
+                set_pos = set_pos.item()
+            except AttributeError:
+                pass
             if isinstance(set_pos, str):
                 self._setables[name].set_identifier(set_pos)
             elif set_pos is None:

--- a/yaqd_attune/_attune.py
+++ b/yaqd_attune/_attune.py
@@ -49,7 +49,8 @@ class Attune(HasDependents, HasLimits, IsHomeable, HasPosition, IsDaemon):
         for name, set_pos in self._instrument(position, self._state["arrangement"]).items():
             if name in exceptions:
                 continue
-            set_pos = set_pos.item()  # needs attune > 0.5.1
+            if isinstance(set_pos, np.ndarray):
+                set_pos = set_pos.item()
             if isinstance(set_pos, str):
                 self._setables[name].set_identifier(set_pos)
             elif set_pos is None:


### PR DESCRIPTION
attune now has normalized output (every note is made up of numpy scalars), but for compatibility with older versions of attune, this PR ensures numpy scalars, strings, and floats are all handled correctly 

* resolves #44 